### PR TITLE
Updating license to be a valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "polaris",
   "version": "1.0.0",
-  "license": "Apache 2",
+  "license": "Apache-2.0",
   "private": true,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes warning during `npm install`